### PR TITLE
Shebang and dependencies fixes

### DIFF
--- a/gtfo
+++ b/gtfo
@@ -1,4 +1,4 @@
-#!/bin/python
+#! /usr/bin/env python
 
 import argparse
 import signal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pyyaml
 requests
 bs4
+lxml
 requests_cache
 tabulate
 pyfiglet


### PR DESCRIPTION
Change gtfo shebang to /usr/bin/env to make it work on most Linux distributions
Added missing lxml dependency

The path `/bin/python` will not work on most Debian based distro, but replacing it with env might help. Most distros provide `env` in either `/bin` or `/usr/bin`. In the first case, `/usr/bin/env` is usally symlinked to its counterpart.
Also, virtualenv relies on `$PATH` so using an absolute path for the python executable would prevent its usage.
If, as the wiki shows, this software targets python3, it may be better to execute it with `python3`.

On a side note, there is typo in the wiki (Installation page), both headers are `Without virtualenv`, rather than one of them being `With virtualenv` (which also breaks the link from the TOC in the Home page).